### PR TITLE
Refactor API endpoints to support limiting results

### DIFF
--- a/api/fansites.ts
+++ b/api/fansites.ts
@@ -17,7 +17,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 }
 
 const getFunction = async (req: VercelRequest, res: VercelResponse, collection) => {
-  const fansites = await collection.find({}).toArray()
+  const limit: number = parseInt(req.query.limit as string) || 0;
+  let fansites = await collection.find({}).toArray()
+  if(limit > 0) {
+    fansites = fansites.slice(0, limit);
+  }
   const result: Array<fansiteExportType> = fansites.map((fansite) => {
     return {
       id: fansite.id,

--- a/api/servers.ts
+++ b/api/servers.ts
@@ -20,7 +20,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 }
 
 const getFunction = async (req: VercelRequest, res: VercelResponse, collection) => {
-  const servers = await collection.find({}).toArray()
+  const limit: number = parseInt(req.query.limit as string) || 0;
+  let servers = await collection.find({}).toArray()
+  if(limit > 0) {
+    servers = servers.slice(0, limit);
+  }
   const result: Array<serverExportType> = servers.map((server) => {
     return {
       id: server.id,


### PR DESCRIPTION
# Changes

- Add new query `limit` for limiting number of results